### PR TITLE
Update seed users to saas credentials

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -5,8 +5,8 @@ import * as bcrypt from 'bcrypt';
 const prisma = new PrismaClient();
 
 async function main() {
-  const adminPassword = process.env.SEED_ADMIN_PASSWORD ?? 'Admin123!';
-  const memberPassword = process.env.SEED_MEMBER_PASSWORD ?? 'Member123!';
+  const adminPassword = process.env.SEED_ADMIN_PASSWORD ?? 'Password1';
+  const memberPassword = process.env.SEED_MEMBER_PASSWORD ?? 'Password1';
   const saltRounds = Number(process.env.BCRYPT_SALT_ROUNDS ?? 12);
 
   const [company] = await prisma.$transaction(async (tx) => {
@@ -21,7 +21,7 @@ async function main() {
       where: {
         companyId_email: {
           companyId: company.id,
-          email: 'admin@ort.com',
+          email: 'admin@saas.com',
         },
       },
       update: {
@@ -31,7 +31,7 @@ async function main() {
       },
       create: {
         companyId: company.id,
-        email: 'admin@ort.com',
+        email: 'admin@saas.com',
         passwordHash: adminHash,
         role: UserRole.ADMIN,
         forcePasswordReset: false,
@@ -43,7 +43,7 @@ async function main() {
       where: {
         companyId_email: {
           companyId: company.id,
-          email: 'member@ort.com',
+          email: 'usuario@saas.com',
         },
       },
       update: {
@@ -53,7 +53,7 @@ async function main() {
       },
       create: {
         companyId: company.id,
-        email: 'member@ort.com',
+        email: 'usuario@saas.com',
         passwordHash: memberHash,
         role: UserRole.MEMBER,
         forcePasswordReset: false,


### PR DESCRIPTION
## Summary
- change the default seeded admin and member emails to use the saas.com domain
- update the default seeded passwords to Password1 for both users

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf3599e7f88331a370486e244a37b4